### PR TITLE
database dockerise

### DIFF
--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -1,0 +1,18 @@
+{
+  "configurations": [
+    {
+      "name": "windows-gcc-x86",
+      "includePath": [
+        "${workspaceFolder}/**"
+      ],
+      "compilerPath": "C:/MinGW/bin/gcc.exe",
+      "cStandard": "${default}",
+      "cppStandard": "${default}",
+      "intelliSenseMode": "windows-gcc-x86",
+      "compilerArgs": [
+        ""
+      ]
+    }
+  ],
+  "version": 4
+}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,24 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "C/C++ Runner: Debug Session",
+      "type": "cppdbg",
+      "request": "launch",
+      "args": [],
+      "stopAtEntry": false,
+      "externalConsole": true,
+      "cwd": "c:/Users/doem1/Desktop",
+      "program": "c:/Users/doem1/Desktop/build/Debug/outDebug",
+      "MIMode": "gdb",
+      "miDebuggerPath": "gdb",
+      "setupCommands": [
+        {
+          "description": "Enable pretty-printing for gdb",
+          "text": "-enable-pretty-printing",
+          "ignoreFailures": true
+        }
+      ]
+    }
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,59 @@
+{
+  "C_Cpp_Runner.cCompilerPath": "gcc",
+  "C_Cpp_Runner.cppCompilerPath": "g++",
+  "C_Cpp_Runner.debuggerPath": "gdb",
+  "C_Cpp_Runner.cStandard": "",
+  "C_Cpp_Runner.cppStandard": "",
+  "C_Cpp_Runner.msvcBatchPath": "C:/Program Files/Microsoft Visual Studio/2022/Community/VC/Auxiliary/Build/vcvarsall.bat",
+  "C_Cpp_Runner.useMsvc": false,
+  "C_Cpp_Runner.warnings": [
+    "-Wall",
+    "-Wextra",
+    "-Wpedantic",
+    "-Wshadow",
+    "-Wformat=2",
+    "-Wcast-align",
+    "-Wconversion",
+    "-Wsign-conversion",
+    "-Wnull-dereference"
+  ],
+  "C_Cpp_Runner.msvcWarnings": [
+    "/W4",
+    "/permissive-",
+    "/w14242",
+    "/w14287",
+    "/w14296",
+    "/w14311",
+    "/w14826",
+    "/w44062",
+    "/w44242",
+    "/w14905",
+    "/w14906",
+    "/w14263",
+    "/w44265",
+    "/w14928"
+  ],
+  "C_Cpp_Runner.enableWarnings": true,
+  "C_Cpp_Runner.warningsAsError": false,
+  "C_Cpp_Runner.compilerArgs": [],
+  "C_Cpp_Runner.linkerArgs": [],
+  "C_Cpp_Runner.includePaths": [],
+  "C_Cpp_Runner.includeSearch": [
+    "*",
+    "**/*"
+  ],
+  "C_Cpp_Runner.excludeSearch": [
+    "**/build",
+    "**/build/**",
+    "**/.*",
+    "**/.*/**",
+    "**/.vscode",
+    "**/.vscode/**"
+  ],
+  "C_Cpp_Runner.useAddressSanitizer": false,
+  "C_Cpp_Runner.useUndefinedSanitizer": false,
+  "C_Cpp_Runner.useLeakSanitizer": false,
+  "C_Cpp_Runner.showCompilationTime": false,
+  "C_Cpp_Runner.useLinkTimeOptimization": false,
+  "C_Cpp_Runner.msvcSecureNoWarnings": false
+}

--- a/dockerfile.mysql
+++ b/dockerfile.mysql
@@ -1,0 +1,15 @@
+# Use the official MySQL base image
+FROM mysql
+
+# Environment variables for MySQL
+ENV MYSQL_ROOT_PASSWORD=12345
+ENV MYSQL_DATABASE=CRS
+
+# Copy SQL scripts to initialize the database
+COPY init.sql /docker-entrypoint-initdb.d/
+
+# Expose port 3306 to the outside world
+EXPOSE 3306
+
+# Command to run when the container starts
+CMD ["mysqld"]

--- a/init.sql
+++ b/init.sql
@@ -1,0 +1,19 @@
+-- init.sql
+CREATE TABLE IF NOT EXISTS users (
+    userid INT AUTO_INCREMENT PRIMARY KEY,
+    name VARCHAR(50) NOT NULL,
+    email VARCHAR(50) UNIQUE NOT NULL,
+    password VARCHAR(50) NOT NULL,
+    usertype ENUM('doctor', 'patient') NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS appointments (
+    appointment_id INT AUTO_INCREMENT PRIMARY KEY,
+    doctor_id INT NOT NULL,
+    patient_id INT,
+    appointment_date DATE NOT NULL,
+    start_time TIME NOT NULL,
+    end_time TIME NOT NULL,
+    FOREIGN KEY (doctor_id) REFERENCES users(userid),
+    FOREIGN KEY (patient_id) REFERENCES users(userid)
+);


### PR DESCRIPTION
Created the dockerfile.mysql to create the image database using docker.

The MySQL root password is set to "12345," the database is named "CRS," and a MySQL user with the name "root". The init.sql script is copied to the /docker-entrypoint-initdb.d/ directory, ensuring that it will be executed when the container starts.

dockerfile.mysql:
FROM mysql: Specifies the base image as the official MySQL Docker image with the latest version

ENV: Sets environment variables for MySQL. You can customize these variables based on your requirements. In this example, we set the root password, create a database, and create a user with a password.

COPY init.sql /docker-entrypoint-initdb.d/: Copies an initialization SQL script (assuming you have one) into the /docker-entrypoint-initdb.d/ directory. The SQL script will be executed when the container starts.

EXPOSE 3306: Informs Docker that the container will listen on port 3306.

CMD ["mysqld"]: Specifies the command to run when the container starts. In this case, it starts the MySQL daemon.

init.sql: script for creating tables if not exist.

To create the image:
docker build -t database . -f  ~/dockerfile.mysql

To create the container:
docker run -d -p 3306:3306 --name dbcontainer database